### PR TITLE
automatically retrieve technology-data, drop git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ Finally, when the workflow is complete, the results will be stored in `results` 
 ## Requirements
 ### Data
 
-Code is based on the brownfield networks exported from [PyPSA-Eur-Sec](https://github.com/PyPSA/pypsa-eur-sec) with `myopic` setting to get brownfield networks for 2025/2030. For convenience, the sample networks are pushed to git and located in the `input` folder.
+Code is based on the brownfield networks exported from [PyPSA-Eur](https://github.com/PyPSA/pypsa-eur-sec) with `myopic` setting to get brownfield networks for 2025/2030. For convenience, sample networks are provided in the `input/` folder.
 
-Parallel to the repository you should also clone the [technology-data](https://github.com/PyPSA/technology-data) repository.
+Technology data assumptions are automatically retrieved from [technology-data](https://github.com/PyPSA/technology-data) repository for `<year>` and `<version>`, as specified in `config.yaml`.
 
 
 ### Software
 
-The code is known to work with python 3.11, PyPSA 0.23, pandas 1.5.3, numpy 1.24.2, linopy 0.1.5, and gurobi 10.0.1.
+The code is known to work with python 3.11, PyPSA 0.25, pandas 1.5.3, numpy 1.24.2, linopy 0.2.7, and gurobi 10.0.1.
 
 The complete list of package requirements is in the [envs/environment.yaml](envs/environment.yaml) file. The environment can be installed and activated using:
 

--- a/config.yaml
+++ b/config.yaml
@@ -2,17 +2,28 @@
 #
 # SPDX-License-Identifier: MIT
 
+###################
+# General settings
+
 logging_level: INFO
-solve_network: solve  #'solve' or 'skip'
-
+solve_network: solve  #'solve' or 'skip' to skip network optimization step
 results_dir: 'results'
-costs_dir: '../technology-data/outputs'
 
-# from ../pypsa-eur-sec/results/<run>/prenetworks-brownfield
+###################
+# Data dependencies
+
+# Networks retrieved from ../pypsa-eur/results/<run>/prenetworks-brownfield
 n_2025_1H: 'input/elec_s_37_lv1.0__1H-B-solar+p3_2025.nc'
 n_2030_1H: 'input/elec_s_37_lv1.0__1H-B-solar+p3_2030.nc'
 n_2025_3H: 'input/elec_s_37_lv1.0__3H-B-solar+p3_2025.nc'
 n_2030_3H: 'input/elec_s_37_lv1.0__3H-B-solar+p3_2030.nc'
+
+# Retrieve technology data <version> for <year>
+# Source https://github.com/PyPSA/technology-data
+retrieve_cost_data: true
+technology_data:
+  year: 2025
+  version: v0.6.2
 
 ###################
 # Scenario controls
@@ -31,7 +42,7 @@ scenario:
         "IE" #37-node network of ENTSO-E area | possible toy zones: "IE", "DK", "DE",  FR", "IEDK", "DKDE"
         ]
   year: [ '2025',
-         #'2030'
+          #'2030'
          ] # controls both the brownfield fleet and tech costs projection
 
 ci:

--- a/scripts/solve_network.py
+++ b/scripts/solve_network.py
@@ -179,16 +179,8 @@ def timescope(year):
     d = dict()
 
     d["coal_phaseout"] = snakemake.config[f"policy_{year}"]
-
-    if year == "2030":
-        d["network_file"] = snakemake.input.network2030
-        d["costs_projection"] = snakemake.input.costs2030
-    elif year == "2025":
-        d["network_file"] = snakemake.input.network2025
-        d["costs_projection"] = snakemake.input.costs2025
-    else:
-        print(f"'year' wildcard must be one of '2025', '2030'. Now is {year}.")
-        sys.exit()
+    d["network_file"] = snakemake.input.network
+    d["costs_projection"] = snakemake.input.costs
 
     return d
 
@@ -1432,11 +1424,11 @@ if __name__ == "__main__":
         os.chdir(os.path.dirname(os.path.abspath(__file__)))
         snakemake = mock_snakemake(
             "solve_network",
-            year="2025",
-            zone="DKDE",
+            year="2030",
+            zone="IE",
             palette="p1",
             policy="cfe100",
-            flexibility="40",
+            flexibility="0",
         )
 
     logging.basicConfig(


### PR DESCRIPTION
Phase out the need to clone technology-data repository in a parallel directory.

This solution directly retrieves the technology-data from https://github.com/PyPSA/technology-data/tree/master/outputs

This solution also improves reproducibility, since the data retrieval can be fixed for a specific version of technology-data.



