### PR TITLE
add retrieve_cost_data, remove depreciated function, clean workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Second, install the necessary dependencies using `environment.yml` file. The fol
 
 ```
 conda env create -f envs/environment.yml
-conda activate 247-cfe
+conda activate 247-env
 ```
 Third, to run all the scenarios from the study, run the [snakemake](https://snakemake.readthedocs.io/en/stable/) worflow:
 
@@ -114,7 +114,7 @@ conda activate 247-env
 3. The results of the paper can be reproduced by running the [snakemake](https://snakemake.readthedocs.io/en/stable/) workflow.  The following commands will run the workflows for the paper:
 
 ```
-snakemake --cores <n> --configfile config_247cfe
+snakemake --cores <n> --configfile config_247cfe.yaml
 snakemake --cores <n> --configfile config_BackgroundSystem.yaml
 ```
 

--- a/config.yaml
+++ b/config.yaml
@@ -243,6 +243,7 @@ tech_colors:
   "iron-air": "#d26303"
   "iron-air inverter": "#d26303"
   "iron-air storage": "#d26303"
+  "ironair storage": "#d26303"
   "hydrogen storage": "#990090"
   "hydrogen fuel cell": "#990090"
   "hydrogen electrolysis": "#550055"

--- a/scripts/plot_maps.py
+++ b/scripts/plot_maps.py
@@ -76,7 +76,7 @@ def plot_map(
     # Drop data center nodes
     for name in datacenters:
         if name in n.buses.index:
-            n.mremove("Bus", [name])
+            n.remove("Bus", [name])
 
     # Empty dataframe indexed with electrical buses
     index = pd.DataFrame(index=n.buses.index)
@@ -259,7 +259,7 @@ def plot_datacenters(network, datacenters):
     # Drop data center nodes
     for name in datacenters:
         if name in n.buses.index:
-            n.mremove("Bus", [name])
+            n.remove("Bus", [name])
 
     # Load the geometries of datacenters
     world = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))

--- a/scripts/retrieve_cost_data.py
+++ b/scripts/retrieve_cost_data.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Contributors to PyPSA-Eur <https://github.com/pypsa/pypsa-eur>
+#
+# SPDX-License-Identifier: MIT
+"""
+Retrieve cost data from ``technology-data``.
+"""
+
+import logging
+from pathlib import Path
+from _helpers import progress_retrieve
+
+logger = logging.getLogger(__name__)
+
+if __name__ == "__main__":
+    if "snakemake" not in globals():
+        from _helpers import mock_snakemake
+
+        snakemake = mock_snakemake("retrieve_cost_data", year=2030)
+        rootpath = ".."
+    else:
+        rootpath = "."
+
+    version = snakemake.params.version
+    if "/" in version:
+        baseurl = f"https://raw.githubusercontent.com/{version}/outputs/"
+    else:
+        baseurl = f"https://raw.githubusercontent.com/PyPSA/technology-data/{version}/outputs/"
+    filepath = Path(snakemake.output[0])
+    url = baseurl + filepath.name
+
+    print(url)
+
+    to_fn = Path(rootpath) / filepath
+
+    print(to_fn)
+
+    logger.info(f"Downloading technology data from '{url}'.")
+    disable_progress = False
+    progress_retrieve(url, to_fn, disable=disable_progress)
+
+    logger.info(f"Technology data available at at {to_fn}")

--- a/scripts/summarise_network.py
+++ b/scripts/summarise_network.py
@@ -5,7 +5,6 @@
 import pypsa, numpy as np, pandas as pd
 import yaml
 from solve_network import palette
-from _helpers import override_component_attrs
 
 
 def weighted_avg(cfe, weights):
@@ -618,7 +617,7 @@ def summarise_network(n, policy, tech_palette):
 
         ### collect data
         data = n.statistics.optimal_capacity(
-            bus_carrier="AC", groupby=n.statistics.groupers.get_bus_and_carrier
+            bus_carrier="AC", groupby=["bus", "carrier"]
         ).round(1)
         data = data.droplevel(0)
         df_reset = data.reset_index()
@@ -832,9 +831,7 @@ if __name__ == "__main__":
     print(f"Summary for flexibility: {flexibility}")
 
     # Read data
-    n = pypsa.Network(
-        snakemake.input.network, override_component_attrs=override_component_attrs()
-    )
+    n = pypsa.Network(snakemake.input.network)
 
     grid_cfe_df = pd.read_csv(
         snakemake.input.grid_cfe, index_col=0, parse_dates=True, header=[0, 1]


### PR DESCRIPTION
Here are the proposed changes following the code testing on March 17, 2025. Since most of the environment versions are not locked, several deprecated functions were encountered, but they remain manageable.

- `override_component_attrs()` are no longer necessary https://github.com/PyPSA/pypsa-eur/pull/695 
- `HTTP = HTTPRemoteProvider()` no longer work, use the standard PyPSA-Eur `retrieve_cost_data.py` instead
- Replace `sum(dims=[])` to `sum(dim=[])`
- Replace `n.mremove` to `n.remove`
- Adjust `n.statistics` groupby=["bus", "carrier"]

Hope this helps!
